### PR TITLE
Fixed Bug (missing comma)

### DIFF
--- a/.hyper.js
+++ b/.hyper.js
@@ -8,7 +8,7 @@ module.exports = {
     cursorShape: 'BLOCK',
     wickedBorder: true,
     padding: '10px',
-    shell: '/bin/zsh'
+    shell: '/bin/zsh',
   },
 
 


### PR DESCRIPTION
There was a missing comma at this line  " shell: '/bin/zsh', " . Because of that hyper wasn't working properly.